### PR TITLE
Add note about defining "magento root dir"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Compatibility
 Installation Instructions
 -------------------------
 1. Install via composer: `composer require integer-net/anonymizer`
+
+   If the above command prompts you to `please define your magento root dir`, enter `./`
 2. Configure Magento-PSR-0-Autoloader to use the composer autoloader. Add this to the `global` node of your `app/etc/local.xml`:
 
         <composer_vendor_path><![CDATA[{{root_dir}}/vendor]]></composer_vendor_path>


### PR DESCRIPTION
I'm working on an M1>M2 migration and needed to anonymize the M1 data before sharing with a vendor.

I initially entered an invalid value for the "magento root dir", so I thought it might be useful to have this information in the readme.